### PR TITLE
default install-file is project.projectDir/src/main/izpack/install.xml...

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/izpack/IzPackPlugin.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/izpack/IzPackPlugin.groovy
@@ -64,7 +64,7 @@ class IzPackPlugin implements Plugin<Project> {
     }
 
     private File getInstallFile(Project project, IzPackPluginConvention izPackConvention) {
-        File installFileDir = new File('src/main/izpack')
+        File installFileDir = new File(project.projectDir, 'src/main/izpack')
         izPackConvention.installFile ?: new File(installFileDir, 'install.xml')
     }
 


### PR DESCRIPTION
...
instead of just src/main/izpack/install.xml

Otherwise the default file is not found in a multi-project build
