### PR TITLE
Added sourceCompatibility field.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ apply plugin: 'com.jfrog.bintray'
 
 group = 'com.bmuschko'
 version = '2.0'
+sourceCompatibility = '1.6'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
I am working on an enterprise application which runs on jdk 1.6, and we need this plugin to be built on the same jdk version. That's why I added the sourceCompatibility field to the build script.