### PR TITLE
Project extra property for task class

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/izpack/IzPackPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/izpack/IzPackPlugin.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.Project
  */
 class IzPackPlugin implements Plugin<Project> {
     static final String IZPACK_CONFIGURATION_NAME = 'izpack'
+    static final String IZPACK_TASK_NAME = 'izPackCreateInstaller'
 
     @Override
     void apply(Project project) {
@@ -36,6 +37,7 @@ class IzPackPlugin implements Plugin<Project> {
         project.convention.plugins.cargo = izPackConvention
 
         configureCreateInstallerTask(project, izPackConvention)
+        project.ext.set(IZPACK_TASK_NAME, CreateInstallerTask.class)
     }
 
     private void configureCreateInstallerTask(Project project, IzPackPluginConvention izPackConvention) {
@@ -50,7 +52,7 @@ class IzPackPlugin implements Plugin<Project> {
             createInstallerTask.conventionMapping.map('appProperties') { izPackConvention.appProperties }
         }
 
-        CreateInstallerTask createInstallerTask = project.tasks.create('izPackCreateInstaller', CreateInstallerTask)
+        CreateInstallerTask createInstallerTask = project.tasks.create(IZPACK_TASK_NAME, CreateInstallerTask)
         createInstallerTask.description = 'Creates an IzPack-based installer'
         createInstallerTask.group = 'installation'
     }


### PR DESCRIPTION
In my project for separate installers I had two tasks of type com.bmuschko.gradle.izpack.CreateInstallerTask.
I found it useful to have extra property, that points to this task class. As a result it's usage became more clear:
```
    task izPackCreateOSXInstaller(type: izPackCreateInstaller) {
        installFile = file("installer/tmp/installerMac.xml")
        outputFile = file("installer/output/${appName}-${appVersion}-macosx.jar")
    }
```
It would be good to have it out of the box!